### PR TITLE
fix cpm-build specific videoOSD buttons

### DIFF
--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -1166,6 +1166,8 @@
         <param name="button_6">false</param>
         <param name="button_7">false</param>
         <param name="button_8">false</param>
+        <param name="button_9">false</param>
+        <param name="button_10">false</param>
         <param name="iconoffset_condition">false</param>
         <definition>
 
@@ -1261,6 +1263,14 @@
                     <param name="icon">$PARAM[icon]</param>
                     <param name="label">$PARAM[label]</param>
                     <param name="iconoffset_condition">$PARAM[iconoffset_condition]</param>
+                </include>
+
+                <include content="OSD_CustomDialog_FakeButton" condition="![$PARAM[button_9]]">
+                    <param name="id">9</param>
+                </include>
+
+                <include content="OSD_CustomDialog_FakeButton" condition="![$PARAM[button_10]]">
+                    <param name="id">10</param>
                 </include>
 
                 <include content="OSD_CustomDialog_FakeButton" condition="![$PARAM[button_6]]">

--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -133,28 +133,28 @@
                         </include>
 						
                         <!-- Button PlayerProcessInfo -->
-                        <control type="button" id="6015">
+                        <control type="button" id="6009">
                             <include>Defs_OSD_Button</include>
                             <onclick>CancelAlarm(osd_timeout,true)</onclick>
                             <onclick>ActivateWindow(playerprocessinfo)</onclick>
                         </control>
                         <include content="OSD_Button_Icon_Overlay">
                             <param name="icon">special://skin/extras/icons/ppi.png</param>
-                            <param name="id">6015</param>
-                            <param name="groupid">6115</param>
+                            <param name="id">6009</param>
+                            <param name="groupid">6109</param>
                             <param name="itemgap">osd_itemgap</param>
                         </include>
 					
                         <!-- Button VS10 -->
-                        <control type="button" id="6016">
+                        <control type="button" id="60010">
                             <include>Defs_OSD_Button</include>
                             <onclick>CancelAlarm(osd_timeout,true)</onclick>
                             <onclick>ActivateWindow(1189)</onclick>
                         </control>
                         <include content="OSD_Button_Icon_Overlay">
                             <param name="icon">special://skin/extras/icons/vs10.png</param>
-                            <param name="id">6016</param>
-                            <param name="groupid">6116</param>
+                            <param name="id">60010</param>
+                            <param name="groupid">61010</param>
                             <param name="itemgap">osd_itemgap</param>
                         </include>
 


### PR DESCRIPTION
Hi!

Today I noticed that the recent changes broke the cpm-build specific VideoOSD buttons – i.e. they can no longer be focused.

I tested the proposed fix in both VideoOSD and MusicOSD, and everything seems to be working as expected.